### PR TITLE
Ability to easily filter out keys with null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+### Added
+- `NormalizationContext::markNullValuesForRemoval` method to be called in normalizers.
+If this is called, elements with `null` values will be removed from currently normalized object.
+
 ## [1.0.0]
 ### Changed
 - `null` values are kept by `DataFilter` and will be available in resulted normalized data.
@@ -28,3 +33,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [1.0.0]: https://github.com/paysera/lib-normalization/compare/0.1.3...1.0.0
+[1.1.0]: https://github.com/paysera/lib-normalization/compare/1.0.0...1.1.0

--- a/src/DataFilter.php
+++ b/src/DataFilter.php
@@ -37,10 +37,16 @@ class DataFilter
     {
         $result = new stdClass();
         foreach ($data as $key => $value) {
-            $key = (string)$key;
-            if ($context->isFieldIncluded($key)) {
-                $result->$key = $this->filterData($value, $context->createScopedContext($key));
+            if ($context->areNullValuesRemoved() && $value === null) {
+                continue;
             }
+
+            $key = (string)$key;
+            if (!$context->isFieldIncluded($key)) {
+                continue;
+            }
+
+            $result->$key = $this->filterData($value, $context->createScopedContext($key));
         }
         return $result;
     }

--- a/src/NormalizationContext.php
+++ b/src/NormalizationContext.php
@@ -10,6 +10,7 @@ class NormalizationContext
     private $includedFields;
     private $path;
     private $normalizationGroup;
+    private $nullValuesRemoved;
 
     public function __construct(
         CoreNormalizer $coreNormalizer,
@@ -20,6 +21,7 @@ class NormalizationContext
         $this->setIncludedFields($includedFields);
         $this->normalizationGroup = $normalizationGroup;
         $this->path = [];
+        $this->nullValuesRemoved = false;
     }
 
     private function setIncludedFields(array $includedFields, bool $defaultFieldsIncluded = false)
@@ -57,6 +59,7 @@ class NormalizationContext
     public function createScopedContext(string $fieldName): self
     {
         $context = clone $this;
+        $context->nullValuesRemoved = false;
 
         if ($this->isArrayItem($fieldName)) {
             return $context;
@@ -90,5 +93,15 @@ class NormalizationContext
     private function isArrayItem(string $fieldName)
     {
         return $fieldName === '';
+    }
+
+    public function markNullValuesForRemoval()
+    {
+        $this->nullValuesRemoved = true;
+    }
+
+    public function areNullValuesRemoved(): bool
+    {
+        return $this->nullValuesRemoved;
     }
 }

--- a/tests/Fixtures/Normalizer/FilterOutNullsNormalizer.php
+++ b/tests/Fixtures/Normalizer/FilterOutNullsNormalizer.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Paysera\Component\Normalization\Tests\Fixtures\Normalizer;
+
+use Paysera\Component\Normalization\NormalizationContext;
+use Paysera\Component\Normalization\NormalizerInterface;
+use Paysera\Component\Normalization\Tests\Fixtures\Entity\MyData;
+
+class FilterOutNullsNormalizer implements NormalizerInterface
+{
+    /**
+     * @param MyData $data
+     * @param NormalizationContext $normalizationContext
+     *
+     * @return mixed
+     */
+    public function normalize($data, NormalizationContext $normalizationContext)
+    {
+        $normalizationContext->markNullValuesForRemoval();
+        return [
+            'property' => $data->getProperty(),
+            'inner' => $data->getInnerData(),
+            'inner_list' => $data->getInnerDataList(),
+        ];
+    }
+}


### PR DESCRIPTION
This could be used, for example, in `ErrorNormalizer` in `lib-api-bundle`.
If this is desired behaviour, this approach allows much more readable code than having if-else statements inside our normalizers or wrapping result into custom `array_filter` function.